### PR TITLE
Update to version 1.0.31

### DIFF
--- a/goalfeed/Dockerfile
+++ b/goalfeed/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Set the version of the goalfeed binary you want to fetch
-ARG GOALFEED_VERSION=v1.0.27
+ARG GOALFEED_VERSION=v1.0.31
 
 
 RUN ARCH=$(uname -m) && \

--- a/goalfeed/config.yaml
+++ b/goalfeed/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Goalfeed
-version: "1.0.27"
+version: "1.0.31"
 slug: goalfeed
 description: A service that will provide "goal" events within Home Assistant whenever your favourite MLB or NHL team scores. 
 url: "https://github.com/goalfeed/hassio-goalfeed-repository/tree/main/goalfeed"


### PR DESCRIPTION
This PR updates the version to 1.0.31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Goalfeed to v1.0.31 across Dockerfile and add-on config.
> 
> - **Version bump**:
>   - Update `GOALFEED_VERSION` in `goalfeed/Dockerfile` to `v1.0.31`.
>   - Update `version` in `goalfeed/config.yaml` to `"1.0.31"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 702a93ee4ace8130fbaa8a91d1d602e44771773c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->