### PR TITLE
Revert "Expose web UI and API in addon config"

### DIFF
--- a/goalfeed/DOCS.md
+++ b/goalfeed/DOCS.md
@@ -1,14 +1,6 @@
 # Home Assistant Community Add-on: GoalFeed
 
-The Home Assistant GoalFeed add-on provides real-time goal updates for NHL and MLB games, featuring a web interface and REST API for monitoring your favorite teams.
-
-## Features
-
-- **Real-time Goal Events**: Automatic notifications when your teams score
-- **Web Interface**: Interactive scoreboard and team management UI
-- **REST API**: Programmatic access to games, events, and team data
-- **WebSocket Support**: Real-time updates via WebSocket connection
-- **Multi-League Support**: NHL and MLB teams
+The Home Assistant GoalFeed add-on allows you to [brief description of what the add-on does].
 
 ## Installation
 
@@ -21,52 +13,8 @@ The installation of this add-on is similar to other Home Assistant add-ons.
 5. Once installed in the configuration tab, enter the two or three letter code for the teams you want to get events for (ie. WPG, TOR, NYY)
 6. Start the "Goalfeed" add-on and check the logs to ensure everything is running smoothly.
 
-## Accessing the Web Interface
-
-After starting the add-on, you can access the web interface in two ways:
-
-1. **Via Home Assistant Panel**: Click on the Goalfeed icon in the Home Assistant sidebar
-2. **Direct Access**: Navigate to port 8080 on your Home Assistant host
-
-The web interface provides:
-- Live scoreboard with real-time game updates
-- Team management for configuring which teams to monitor
-- Event feed showing recent goals and scores
-
-## API Documentation
-
-The add-on exposes a REST API on port 8080:
-
-- **API Base URL**: `http://[your-host]:8080/api`
-- **Swagger Documentation**: `http://[your-host]:8080/swagger/index.html`
-- **WebSocket**: `ws://[your-host]:8080/ws`
-
-### Key API Endpoints
-
-- `GET /api/games` - Get all active games
-- `GET /api/leagues` - Get league configurations
-- `POST /api/leagues` - Update team configurations
-- `GET /api/events` - Get recent goal events
-- `GET /api/teams` - Get available teams per league
-
 ## Configuration
 
 **Note**: _Remember to restart the add-on when the configuration is changed._
 
-### Configuration Options
-
-- **nhl_teams**: Comma-separated list of NHL team codes (e.g., "TOR,WPG,NYR")
-- **mlb_teams**: Comma-separated list of MLB team codes (e.g., "TOR,NYY,BOS")
-- **test_goals**: Enable test goals every minute for testing automations (default: false)
-
-### Example Configuration
-
-```yaml
-nhl_teams: "TOR,WPG"
-mlb_teams: "TOR,NYY"
-test_goals: false
-```
-
-## Creating Automations
-
-You can create Home Assistant automations that trigger when your teams score. See the [GoalFeed wiki](https://github.com/goalfeed/goalfeed/wiki/Goal-Automation) for detailed automation examples.
+Refer to the `config.yaml` file in the repository for configuration options and examples.

--- a/goalfeed/config.yaml
+++ b/goalfeed/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Goalfeed
-version: "1.0.31-1"
+version: "1.0.31"
 slug: goalfeed
 description: A service that will provide "goal" events within Home Assistant whenever your favourite MLB or NHL team scores. 
 url: "https://github.com/goalfeed/hassio-goalfeed-repository/tree/main/goalfeed"
@@ -14,14 +14,6 @@ init: false
 image: ghcr.io/goalfeed/hassio-{arch}-goalfeed
 homeassistant_api: true
 hassio_api: true
-ingress: true
-ingress_port: 8080
-panel_icon: mdi:hockey-sticks
-webui: "http://[HOST]:[PORT:8080]"
-ports:
-  8080/tcp: 8080
-ports_description:
-  8080/tcp: Web UI and API
 options:
   nhl_teams: ""
   mlb_teams: ""

--- a/goalfeed/run.sh
+++ b/goalfeed/run.sh
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 
 # Initialize command variable
-CMD="./goalfeed --web --web-port 8080"
+CMD="./goalfeed"
 
 
 sanitize_input() {


### PR DESCRIPTION
Reverts goalfeed/hassio-goalfeed-repository#15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts web UI/API exposure and ingress, updates run command accordingly, and simplifies docs while setting version to 1.0.31.
> 
> - **Add-on config (`goalfeed/config.yaml`)**:
>   - Remove web/ingress exposure: drop `ingress`, `ingress_port`, `panel_icon`, `webui`, `ports`, and `ports_description`.
>   - Set version to `1.0.31` (was `1.0.31-1`).
> - **Runtime (`goalfeed/run.sh`)**:
>   - Drop web server flags: change default command from ``./goalfeed --web --web-port 8080`` to ``./goalfeed``.
> - **Docs (`goalfeed/DOCS.md`)**:
>   - Simplify docs by removing web UI/API details and pointing users to `config.yaml` for configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c571f653528f863c0706bb2cdd998ca76042564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->